### PR TITLE
feat: 설문지 조회 API 연동

### DIFF
--- a/app/(common)/_layout.tsx
+++ b/app/(common)/_layout.tsx
@@ -8,7 +8,7 @@ import SearchBarTextInput from '@/components/searchScreen/SearchBarTextInput';
 const QR_ENTRY_OPTIONS: NativeStackNavigationOptions = {
   ...DEFAULT_STACK_OPTIONS,
   title: '',
-  headerLeft: () => <BackBtn />,
+  headerLeft: () => <BackBtn isNavigateHome={true} />,
 };
 
 const SEARCH_OPTIONS: NativeStackNavigationOptions = {

--- a/app/(common)/survey/index.tsx
+++ b/app/(common)/survey/index.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useRef, useState } from 'react';
 import * as S from './SurveyQuestion.style';
 import CustomGradientBtn from '@/components/customGradientBtn/CustomGradientBtn';
 import CustomGrayBtn from '@/components/customGrayBtn/CustomGrayBtn';
-import { Dimensions, View } from 'react-native';
-import { SurveyQuestionsMock } from '@/mocks/SurveyQuestionsMocks';
+import { ActivityIndicator, Dimensions, Text, View } from 'react-native';
 import { Animated } from 'react-native';
 import { useRouter } from 'expo-router';
+import { useSurveyApi } from '@/hooks/api/useSurveyApi';
+import { usePopUpStore } from '@/store/usePopUpStore';
 
 const QUESTIONS = [
   '어떤 종류의 굿즈를\n가장 선호하시나요?',
@@ -22,10 +23,11 @@ const SurveyQuestionPage: React.FC = () => {
   const [step, setStep] = useState(1);
   const [selected, setSelected] = useState<number | null>(null);
   const [selectedAnswers, setSelectedAnswers] = useState<Record<number, number | null>>({});
-  // const { surveyData } = getSurveyApi;
-  const surveyData = SurveyQuestionsMock; // mock data
-  const answers = surveyData[step - 1].options;
+
+  const popupId = usePopUpStore.getState().selectedPopUpId;
   const router = useRouter();
+  const { questions, isLoading, isError } = useSurveyApi({ popupId });
+  const progress = useRef(new Animated.Value(0)).current;
 
   // step 변경될 때 해당 step의 기존 답변 불러오기
   useEffect(() => {
@@ -34,23 +36,14 @@ const SurveyQuestionPage: React.FC = () => {
 
   // 선택값 불러오기
   useEffect(() => {
-    const currentSurvey = surveyData[step - 1];
-    const saved = selectedAnswers[currentSurvey.surveyId] ?? null;
-    setSelected(saved);
-  }, [step, selectedAnswers, surveyData]);
-
-  // 추후 POST 요청 Body
-  // const requestBody = {
-  //   memberAnswerCreateRequest: surveyData.map(survey => ({
-  //     surveyId: survey.surveyId,
-  //     choiceId: selectedAnswers[survey.surveyId],
-  //   })),
-  // };
-  // console.log(requestBody);
+    if (questions && questions[step - 1]) {
+      const currentSurvey = questions[step - 1];
+      const saved = selectedAnswers[currentSurvey.surveyId] ?? null;
+      setSelected(saved);
+    }
+  }, [step, selectedAnswers, questions]);
 
   // 애니메이션
-  const progress = useRef(new Animated.Value(0)).current;
-
   useEffect(() => {
     Animated.timing(progress, {
       toValue: (step - 1) / (TOTAL - 1),
@@ -58,6 +51,25 @@ const SurveyQuestionPage: React.FC = () => {
       useNativeDriver: false,
     }).start();
   }, [progress, step]);
+
+  if (isLoading) {
+    return <ActivityIndicator />;
+  }
+
+  if (isError || !questions) {
+    return <Text>질문지 내용을 불러올 수 없습니다.</Text>;
+  }
+
+  const answers = questions[step - 1].options;
+
+  // 추후 POST 요청 Body
+  // const requestBody = {
+  //   memberAnswerCreateRequest: questions.map(survey => ({
+  //     surveyId: survey.surveyId,
+  //     choiceId: selectedAnswers[survey.surveyId],
+  //   })),
+  // };
+  // console.log(requestBody);
 
   const fillWidth = progress.interpolate({
     inputRange: [0, 1],
@@ -93,7 +105,7 @@ const SurveyQuestionPage: React.FC = () => {
               onPress={() => {
                 const isSame = selected === answer.choiceId; // 토글
                 const newChoiceId = isSame ? null : answer.choiceId;
-                const currentSurveyId = surveyData[step - 1].surveyId;
+                const currentSurveyId = questions[step - 1].surveyId;
 
                 setSelected(newChoiceId);
                 setSelectedAnswers(prev => ({
@@ -133,7 +145,7 @@ const SurveyQuestionPage: React.FC = () => {
               } else {
                 // 수정: 마지막일 때 제출 로직 호출
                 //handleSubmit(); POST API 호출
-                router.push({ pathname: '/(common)/popUpEntry', params: { isSurvey: 1 } });
+                router.replace({ pathname: '/(common)/popUpEntry', params: { isSurvey: 1 } });
               }
             }}
             style={{ width: BUTTON_WIDTH }}

--- a/app/(tabs)/map/index.tsx
+++ b/app/(tabs)/map/index.tsx
@@ -1,9 +1,12 @@
-import { Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Button, Text, View } from 'react-native';
 
 export default function MapScreen() {
+  const router = useRouter();
   return (
     <View>
       <Text>지도 화면</Text>
+      <Button title="질문지 이동" onPress={() => router.push('/(common)/survey')} />
     </View>
   );
 }

--- a/src/apis/survey/SurveyApi.ts
+++ b/src/apis/survey/SurveyApi.ts
@@ -1,0 +1,10 @@
+import { ApiResponse, GetSurveyQuestionsResponse } from '@/types/api/ApiResponseType';
+import { api } from '../config/Axios';
+import { GetSurveyQuestionsRequest } from '@/types/api/ApiRequestType';
+
+export const getSurveyQuestions = async ({
+  popupId,
+}: GetSurveyQuestionsRequest): ApiResponse<GetSurveyQuestionsResponse> => {
+  const response = await api.get(`/reservations/${popupId}/survey`);
+  return response.data;
+};

--- a/src/components/header/left/backBtn/BackBtn.tsx
+++ b/src/components/header/left/backBtn/BackBtn.tsx
@@ -6,12 +6,18 @@ const images = {
   backButtonIcon: require('@/assets/images/common/right-arrow.webp'),
 };
 
-export default function BackBtn() {
+type Props = {
+  isNavigateHome?: boolean;
+};
+
+export default function BackBtn({ isNavigateHome = false }: Props) {
   const router = useRouter();
 
   return (
     <HeaderLeftWrapper>
-      <S.Container onPress={() => router.back()}>
+      <S.Container
+        onPress={isNavigateHome ? () => router.replace('/(tabs)/home') : () => router.back()}
+      >
         <S.BackButtonIcon source={images.backButtonIcon} />
       </S.Container>
     </HeaderLeftWrapper>

--- a/src/hooks/api/useSurveyApi.ts
+++ b/src/hooks/api/useSurveyApi.ts
@@ -1,0 +1,16 @@
+import { getSurveyQuestions } from '@/apis/survey/SurveyApi';
+import { GetSurveyQuestionsRequest } from '@/types/api/ApiRequestType';
+import { useQuery } from '@tanstack/react-query';
+
+export const useSurveyApi = ({ popupId }: GetSurveyQuestionsRequest) => {
+  const query = useQuery({
+    queryFn: () => getSurveyQuestions({ popupId }),
+    queryKey: ['설문지 조회', popupId],
+  });
+
+  return {
+    questions: query.data?.data,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+};

--- a/src/types/api/ApiRequestType.ts
+++ b/src/types/api/ApiRequestType.ts
@@ -26,3 +26,7 @@ export type GetReservationInfoRequest = {
   popupId: number;
   yyyyMM: string; // 2025-05 형식
 };
+
+export type GetSurveyQuestionsRequest = {
+  popupId: number;
+};

--- a/src/types/api/ApiResponseType.ts
+++ b/src/types/api/ApiResponseType.ts
@@ -68,7 +68,7 @@ export type PostItemSearchResponse = {
   isLast: boolean;
 };
 
-export type SurveyQuestionsResponse = SurveyChoice[];
+export type GetSurveyQuestionsResponse = SurveyChoice[];
 export type GetReservationInfoResponse = {
   popupOpenDate: string;
   popupCloseDate: string;


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-241]

---

## 📌 작업 내용 및 특이사항

- 설문지 조회 API 연동했습니다. 
- 설문지 완료 이후, 이동되는 QR 페이지에서 뒤로가기 버튼을 눌렀을 경우, 설문지 페이지로 다시 라우팅되는 문제가 있었습니다
    - 조건적으로 홈으로 리다이렉션 시킬 수 있또록 코드 수정했습니다.



[LCR-241]: https://lgcns-retail.atlassian.net/browse/LCR-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ