### PR TITLE
feat: 전체 상품 목록 조회 API 구현

### DIFF
--- a/app/(common)/popUpDetail/entireItems/index.tsx
+++ b/app/(common)/popUpDetail/entireItems/index.tsx
@@ -16,12 +16,12 @@ import { usePopUpStore } from '@/store/usePopUpStore';
 
 export default function EntireItemsScreen() {
   const { hotItems } = useLocalSearchParams<{ hotItems: string }>();
-  // const { selectedPopUpId } = usePopUpStore();
+  const { selectedPopUpId } = usePopUpStore();
   const formattedPopularItems = ParseStringToJson(hotItems) as ItemPathType[];
   const { searchResult, isLoading, hasMore, loadMore } = useSearch();
   const { keyword } = useSearchStore();
   const { allItems, isItemLoading, isItemError, allItemsQuery } = usePopUpDetailAllItemsApi({
-    popupId: 1,
+    popupId: selectedPopUpId,
   });
 
   const isSearchMode = keyword.trim().length > 0;

--- a/app/(common)/popUpDetail/entireItems/index.tsx
+++ b/app/(common)/popUpDetail/entireItems/index.tsx
@@ -1,6 +1,6 @@
 import { ParseStringToJson } from '@/utils/JsonParser';
 import { useLocalSearchParams } from 'expo-router';
-import { FlatList, ScrollView, View, ActivityIndicator } from 'react-native';
+import { FlatList, ScrollView, View, ActivityIndicator, Text } from 'react-native';
 import HotItems from '@/components/entireItems/hotItems/HotItems';
 import EntirePageItem from '@/components/entireItems/items/EntirePageItem';
 import { S } from './EntireItems.style';
@@ -8,16 +8,21 @@ import SearchBarTextInput from '@/components/searchScreen/SearchBarTextInput';
 import { useSearchStore } from '@/store/useSearchStore';
 import useSearch from '@/hooks/useSearch';
 import { PostItemSearch } from '@/types/SearchScreenType';
-import { EntireItemMocks } from '@/mocks/PopUpDetailItemMocks';
 import { ItemPathType, ItemUrlType } from '@/types/DetailScreen';
 import NoItem from '@/components/searchScreen/noItem/NoItem';
 import { useCallback } from 'react';
+import { usePopUpDetailAllItemsApi } from '@/hooks/api/usePopUpDetailApi';
+import { usePopUpStore } from '@/store/usePopUpStore';
 
 export default function EntireItemsScreen() {
   const { hotItems } = useLocalSearchParams<{ hotItems: string }>();
+  // const { selectedPopUpId } = usePopUpStore();
   const formattedPopularItems = ParseStringToJson(hotItems) as ItemPathType[];
   const { searchResult, isLoading, hasMore, loadMore } = useSearch();
   const { keyword } = useSearchStore();
+  const { allItems, isItemLoading, isItemError, allItemsQuery } = usePopUpDetailAllItemsApi({
+    popupId: 1,
+  });
 
   const isSearchMode = keyword.trim().length > 0;
 
@@ -94,6 +99,21 @@ export default function EntireItemsScreen() {
     return null;
   }, [searchResult.length, isLoading]);
 
+  const handleDefaultLoadMore = useCallback(() => {
+    if (allItemsQuery.hasNextPage && !allItemsQuery.isFetchingNextPage) {
+      allItemsQuery.fetchNextPage();
+    }
+  }, [allItemsQuery.hasNextPage, allItemsQuery.isFetchingNextPage, allItemsQuery.fetchNextPage]);
+
+  const renderDefaultFooter = useCallback(() => {
+    if (!allItemsQuery.isFetchingNextPage || !allItemsQuery.hasNextPage) return null;
+    return (
+      <View style={{ padding: 20, alignItems: 'center' }}>
+        <ActivityIndicator size="small" color="white" />
+      </View>
+    );
+  }, [allItemsQuery.isFetchingNextPage, allItemsQuery.hasNextPage]);
+
   const renderDefaultHeader = useCallback(
     () => (
       <S.ListHeaderContainer>
@@ -140,19 +160,37 @@ export default function EntireItemsScreen() {
   const renderDefaultContent = useCallback(
     () => (
       <FlatList
-        data={EntireItemMocks}
+        data={allItems}
         style={{ flex: 1 }}
         renderItem={renderDefaultItem}
         numColumns={2}
         columnWrapperStyle={{ justifyContent: 'space-between', gap: 10 }}
-        contentContainerStyle={{ gap: 20, paddingHorizontal: 12 }}
+        contentContainerStyle={{ gap: 20, paddingHorizontal: 12, paddingBottom: 100 }}
         showsVerticalScrollIndicator={false}
         keyExtractor={defaultKeyExtractor}
         ListHeaderComponent={renderDefaultHeader}
+        onEndReached={handleDefaultLoadMore}
+        onEndReachedThreshold={0.3}
+        ListFooterComponent={renderDefaultFooter}
       />
     ),
-    [renderDefaultItem, defaultKeyExtractor, renderDefaultHeader],
+    [
+      renderDefaultItem,
+      defaultKeyExtractor,
+      renderDefaultHeader,
+      allItems,
+      handleDefaultLoadMore,
+      renderDefaultFooter,
+    ],
   );
+
+  if (isItemLoading) {
+    return <ActivityIndicator />;
+  }
+
+  if (isItemError || allItems?.length === 0) {
+    return <Text>조회된 데이터가 없습니다.</Text>;
+  }
 
   return (
     <View style={{ backgroundColor: 'black', flex: 1 }}>

--- a/src/apis/popUpDetail/PopUpDetailApi.ts
+++ b/src/apis/popUpDetail/PopUpDetailApi.ts
@@ -1,0 +1,14 @@
+import { ApiResponse, GetPopUDetailAllItemsResponse } from '@/types/api/ApiResponseType';
+import { api } from '../config/Axios';
+import { GetPopUDetailAllItemsRequest } from '@/types/api/ApiRequestType';
+import { SEARCH_SIZE } from '@/constants/Options';
+
+export const getPopUDetailAllItems = async ({
+  popupId,
+  lastItemId,
+}: GetPopUDetailAllItemsRequest): ApiResponse<GetPopUDetailAllItemsResponse> => {
+  const response = await api.get(
+    `/items/${popupId}?${lastItemId ? `lastItemId=${lastItemId}` : ''}&size=${SEARCH_SIZE}`,
+  );
+  return response.data;
+};

--- a/src/apis/search/SearchApi.ts
+++ b/src/apis/search/SearchApi.ts
@@ -1,27 +1,27 @@
 import {
   ApiResponse,
-  PostItemSearchResponse,
-  PostPopUpSearchResponse,
+  GetItemSearchResponse,
+  GetPopUpSearchResponse,
 } from '@/types/api/ApiResponseType';
 import { api } from '../config/Axios';
-import { PostSearchItemReqeust, PostSearchPopUpRequest } from '@/types/api/ApiRequestType';
 import { SEARCH_SIZE } from '@/constants/Options';
+import { GetSearchItemReqeust, GetSearchPopUpRequest } from '@/types/api/ApiRequestType';
 
-export const postSearchPopUp = async ({
+export const getSearchPopUp = async ({
   keyword,
   lastPopUpId,
-}: PostSearchPopUpRequest): ApiResponse<PostPopUpSearchResponse> => {
+}: GetSearchPopUpRequest): ApiResponse<GetPopUpSearchResponse> => {
   const response = await api.get(
     `/popups?keyword=${keyword}${lastPopUpId ? `&lastPopUpId=${lastPopUpId}` : ''}&size=${SEARCH_SIZE}`,
   );
   return response.data;
 };
 
-export const postSearchPopUpItem = async ({
+export const getSearchPopUpItem = async ({
   keyword,
   selectedPopUpId,
   lastItemId,
-}: PostSearchItemReqeust): ApiResponse<PostItemSearchResponse> => {
+}: GetSearchItemReqeust): ApiResponse<GetItemSearchResponse> => {
   const response = await api.get(
     `/popups/${selectedPopUpId}/items?keyword=${keyword}${lastItemId ? `&lastItemId=${lastItemId}` : ''}&size=${SEARCH_SIZE}`,
   );

--- a/src/hooks/api/usePopUpDetailApi.ts
+++ b/src/hooks/api/usePopUpDetailApi.ts
@@ -1,0 +1,31 @@
+import { getPopUDetailAllItems } from '@/apis/popUpDetail/PopUpDetailApi';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export const usePopUpDetailAllItemsApi = ({ popupId }: { popupId: number }) => {
+  const query = useInfiniteQuery({
+    queryFn: ({ pageParam }) =>
+      getPopUDetailAllItems({
+        popupId,
+        lastItemId: pageParam,
+      }),
+    queryKey: ['details', popupId],
+    getNextPageParam: response => {
+      const lastPage = response.data;
+
+      if (lastPage.isLast) {
+        return undefined;
+      }
+
+      const lastItem = lastPage.content[lastPage.content.length - 1];
+      return lastItem.itemId;
+    },
+    initialPageParam: undefined as number | undefined,
+  });
+
+  return {
+    allItems: query.data?.pages.flatMap(data => data.data.content),
+    isItemLoading: query.isLoading,
+    isItemError: query.isError,
+    allItemsQuery: query,
+  };
+};

--- a/src/hooks/api/useSearchApi.ts
+++ b/src/hooks/api/useSearchApi.ts
@@ -1,10 +1,10 @@
-import { postSearchPopUp, postSearchPopUpItem } from '@/apis/search/SearchApi';
+import { getSearchPopUp, getSearchPopUpItem } from '@/apis/search/SearchApi';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 export const usePopUpSearch = (keyword: string, enabled: boolean) => {
   return useInfiniteQuery({
     queryFn: ({ pageParam }) =>
-      postSearchPopUp({
+      getSearchPopUp({
         keyword,
         lastPopUpId: pageParam,
       }),
@@ -28,7 +28,7 @@ export const useItemSearch = (keyword: string, selectedPopUpId: number, enabled:
   return useInfiniteQuery({
     queryKey: ['itemSearch', keyword],
     queryFn: ({ pageParam }) =>
-      postSearchPopUpItem({ keyword, selectedPopUpId, lastItemId: pageParam }),
+      getSearchPopUpItem({ keyword, selectedPopUpId, lastItemId: pageParam }),
     getNextPageParam: response => {
       const lastPage = response.data;
 

--- a/src/types/api/ApiRequestType.ts
+++ b/src/types/api/ApiRequestType.ts
@@ -1,4 +1,3 @@
-import { ItemUrlType } from '../DetailScreen';
 import { AgeOption, GenderOption } from '../SignUpScreenType';
 
 export type PostLoginRequest = {

--- a/src/types/api/ApiRequestType.ts
+++ b/src/types/api/ApiRequestType.ts
@@ -11,12 +11,12 @@ export type PostSignUpRequest = {
   gender: GenderOption;
 };
 
-export type PostSearchPopUpRequest = {
+export type GetSearchPopUpRequest = {
   keyword: string;
   lastPopUpId: number | undefined;
 };
 
-export type PostSearchItemReqeust = {
+export type GetSearchItemReqeust = {
   keyword: string;
   selectedPopUpId: number;
   lastItemId: number | undefined;

--- a/src/types/api/ApiRequestType.ts
+++ b/src/types/api/ApiRequestType.ts
@@ -1,3 +1,4 @@
+import { ItemUrlType } from '../DetailScreen';
 import { AgeOption, GenderOption } from '../SignUpScreenType';
 
 export type PostLoginRequest = {
@@ -29,4 +30,9 @@ export type GetReservationInfoRequest = {
 
 export type GetSurveyQuestionsRequest = {
   popupId: number;
+};
+
+export type GetPopUDetailAllItemsRequest = {
+  popupId: number;
+  lastItemId: number | undefined;
 };

--- a/src/types/api/ApiResponseType.ts
+++ b/src/types/api/ApiResponseType.ts
@@ -58,12 +58,12 @@ export type GetPopUpDetailResponse = {
   longitude: number;
 };
 
-export type PostPopUpSearchResponse = {
+export type GetPopUpSearchResponse = {
   content: PostPopUpSearch[];
   isLast: boolean;
 };
 
-export type PostItemSearchResponse = {
+export type GetItemSearchResponse = {
   content: ItemUrlType[];
   isLast: boolean;
 };

--- a/src/types/api/ApiResponseType.ts
+++ b/src/types/api/ApiResponseType.ts
@@ -74,3 +74,8 @@ export type GetReservationInfoResponse = {
   popupCloseDate: string;
   reservableDate: ReservableDate[];
 };
+
+export type GetPopUDetailAllItemsResponse = {
+  content: ItemUrlType[];
+  isLast: boolean;
+};


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-246]

---

## 📌 작업 내용 및 특이사항

- 전체 상품 목록 조회 API 구현 진행했습니다.
- 전체 페이지에서 2개의 무한스크롤 (검색 & 전체 상품 조회)가 같이 있어서 추후에 시간되면 코드 분리 도전해보겠습니다

---

## 📚 참고사항

<img width="499" alt="image" src="https://github.com/user-attachments/assets/171c98d0-6b73-40a5-a150-17a4095f040d" />



[LCR-246]: https://lgcns-retail.atlassian.net/browse/LCR-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ