### PR TITLE
feat: 전체 팝업 목록 조회 API 구현

### DIFF
--- a/app/(tabs)/home/HomeScreen.style.ts
+++ b/app/(tabs)/home/HomeScreen.style.ts
@@ -5,8 +5,9 @@ import styled from 'styled-components/native';
 
 export const S = {
   // screen
-  HomeScreenContainer: styled.ScrollView`
+  HomeScreenContainer: styled.View`
     background-color: ${getThemeColor('gray11')};
+    flex: 1;
   `,
 
   // swiper

--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -1,10 +1,11 @@
-import Swiper from 'react-native-swiper';
-import { FlatList } from 'react-native-gesture-handler';
-import { Dimensions, Image } from 'react-native';
+import { ActivityIndicator, Dimensions, FlatList, Image, View } from 'react-native';
 import { S } from './HomeScreen.style';
-import { bannerItems, hotItems, popUpItems } from '@/mocks/HomeMocks';
+import { bannerItems, hotItems } from '@/mocks/HomeMocks';
 import { formatDateRange } from '@/utils/FormatDate';
 import { useRouter } from 'expo-router';
+import { usePopUpStore } from '@/store/usePopUpStore';
+import { usePopUpAllItemsApi } from '@/hooks/api/usePopUpAllItemsApi';
+import Swiper from 'react-native-swiper';
 
 const Images = {
   calendarGray: require('@/assets/images/common/calendar-gray.webp'),
@@ -17,19 +18,48 @@ const HomeScreen = () => {
   const cardGap = 12;
   const cardWidth = (screenWidth - horizontalPadding - cardGap) / 2;
   const router = useRouter();
+  const setSelectedPopUpId = usePopUpStore(state => state.setSelectedPopUpId);
 
-  const groupedPopUps = popUpItems.reduce(
-    (acc, cur, i) => {
-      const row = Math.floor(i / 2);
-      if (!acc[row]) acc[row] = [];
-      acc[row].push(cur);
-      return acc;
-    },
-    [] as (typeof popUpItems)[],
+  const {
+    allItems,
+    allItemsQuery: { fetchNextPage, hasNextPage, isFetchingNextPage },
+  } = usePopUpAllItemsApi();
+
+  const handleEndReached = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  const renderItem = ({ item }: { item: any }) => (
+    <S.PopUpCard
+      cardWidth={cardWidth}
+      onPress={() => {
+        setSelectedPopUpId(item.popupId);
+        router.push('/(common)/popUpDetail');
+      }}
+    >
+      <S.PopUpImage source={{ uri: item.imageUrl }} cardWidth={cardWidth} resizeMode="cover" />
+      <S.PopUpInfo cardWidth={cardWidth}>
+        <S.PopUpCardTitle numberOfLines={1}>{item.popupName}</S.PopUpCardTitle>
+        <S.PopUpCardSubTextContainer>
+          <Image source={Images.calendarGray} style={{ width: 15, height: 15, marginTop: 2 }} />
+          <S.PopUpCardSubText>
+            {formatDateRange(item.popupOpenDate, item.popupCloseDate)}
+          </S.PopUpCardSubText>
+        </S.PopUpCardSubTextContainer>
+        <S.PopUpCardSubTextContainer>
+          <Image source={Images.locationGray} style={{ width: 15, height: 15, marginTop: 3 }} />
+          <S.PopUpCardSubText numberOfLines={1} ellipsizeMode="tail">
+            {item.address}
+          </S.PopUpCardSubText>
+        </S.PopUpCardSubTextContainer>
+      </S.PopUpInfo>
+    </S.PopUpCard>
   );
 
-  return (
-    <S.HomeScreenContainer showsVerticalScrollIndicator={false}>
+  const renderHeader = () => (
+    <View>
       <S.SwiperContainer>
         <Swiper
           autoplay
@@ -52,16 +82,20 @@ const HomeScreen = () => {
           ))}
         </Swiper>
       </S.SwiperContainer>
-      {/* WHAT'S HOT */}
+
       <S.SectionTitle>WHAT’S HOT</S.SectionTitle>
       <FlatList
         data={hotItems}
         keyExtractor={item => String(item.popupId)}
         horizontal
+        scrollEnabled={false}
         showsHorizontalScrollIndicator={false}
         renderItem={({ item, index }) => (
           <S.HotCardContainer
-            onPress={() => router.push('/(common)/popUpDetail')}
+            onPress={() => {
+              setSelectedPopUpId(item.popupId);
+              router.push('/(common)/popUpDetail');
+            }}
             isFirst={index === 0}
           >
             <Image
@@ -75,47 +109,26 @@ const HomeScreen = () => {
           </S.HotCardContainer>
         )}
       />
-      {/* POP-UP NOW! */}
       <S.SectionTitle>POP-UP NOW!</S.SectionTitle>
-      <S.PopUpWrapper>
-        {groupedPopUps.map((row, rowIdx) => (
-          <S.PopUpRow key={`row-${rowIdx}`}>
-            {row.map(item => (
-              <S.PopUpCard
-                key={item.popupId}
-                cardWidth={cardWidth}
-                onPress={() => router.push('/(common)/popUpDetail')}
-              >
-                <S.PopUpImage source={item.imageUrl} cardWidth={cardWidth} resizeMode="cover" />
-                <S.PopUpInfo cardWidth={cardWidth}>
-                  <S.PopUpCardTitle numberOfLines={1}>{item.popupName}</S.PopUpCardTitle>
-                  <S.PopUpCardSubTextContainer>
-                    <Image
-                      source={Images.calendarGray}
-                      style={{ width: 15, height: 15, marginTop: 2 }}
-                    />
-                    <S.PopUpCardSubText>
-                      {formatDateRange(item.popupOpenDate, item.popupCloseDate)}
-                    </S.PopUpCardSubText>
-                  </S.PopUpCardSubTextContainer>
-                  <S.PopUpCardSubTextContainer>
-                    <Image
-                      source={Images.locationGray}
-                      style={{ width: 15, height: 15, marginTop: 3 }}
-                    />
-                    <S.PopUpCardSubText numberOfLines={1} ellipsizeMode="tail">
-                      {item.address}
-                    </S.PopUpCardSubText>
-                  </S.PopUpCardSubTextContainer>
-                </S.PopUpInfo>
-              </S.PopUpCard>
-            ))}
-            {row.length === 1 && <S.PopUpCard cardWidth={cardWidth} />}
-          </S.PopUpRow>
-        ))}
-      </S.PopUpWrapper>
-      <S.BottomArea />
-    </S.HomeScreenContainer>
+    </View>
+  );
+
+  return (
+    <FlatList
+      data={allItems}
+      keyExtractor={item => String(item.popupId)}
+      numColumns={2}
+      columnWrapperStyle={{ gap: cardGap, marginBottom: 12 }}
+      contentContainerStyle={{ paddingHorizontal: 12, paddingBottom: 100 }}
+      showsVerticalScrollIndicator={false}
+      ListHeaderComponent={renderHeader}
+      ListFooterComponent={
+        isFetchingNextPage ? <ActivityIndicator style={{ marginVertical: 20 }} /> : null
+      }
+      onEndReached={handleEndReached}
+      onEndReachedThreshold={0.3}
+      renderItem={renderItem}
+    />
   );
 };
 

--- a/src/apis/home/HomeApi.ts
+++ b/src/apis/home/HomeApi.ts
@@ -1,0 +1,13 @@
+import { ApiResponse, GetPopUpAllItemsResponse } from '@/types/api/ApiResponseType';
+import { api } from '../config/Axios';
+import { GetPopUpAllItemsRequest } from '@/types/api/ApiRequestType';
+import { SEARCH_SIZE } from '@/constants/Options';
+
+export const getPopUpAllItems = async ({
+  lastPopupId,
+}: GetPopUpAllItemsRequest): ApiResponse<GetPopUpAllItemsResponse> => {
+  const response = await api.get(
+    `/popups/?${lastPopupId ? `lastPopupId=${lastPopupId}` : ''}&size=${SEARCH_SIZE}`,
+  );
+  return response.data;
+};

--- a/src/apis/popUpDetail/PopUpDetailApi.ts
+++ b/src/apis/popUpDetail/PopUpDetailApi.ts
@@ -1,16 +1,16 @@
 import {
   ApiResponse,
-  GetPopUDetailAllItemsResponse,
   GetPopUpDetailResponse,
+  GetPopUpDetailAllItemsResponse,
 } from '@/types/api/ApiResponseType';
 import { api } from '../config/Axios';
-import { GetPopUDetailAllItemsRequest, GetPopUpDetailRequest } from '@/types/api/ApiRequestType';
+import { GetPopUpDetailAllItemsRequest, GetPopUpDetailRequest } from '@/types/api/ApiRequestType';
 import { SEARCH_SIZE } from '@/constants/Options';
 
-export const getPopUDetailAllItems = async ({
+export const getPopUpDetailAllItems = async ({
   popupId,
   lastItemId,
-}: GetPopUDetailAllItemsRequest): ApiResponse<GetPopUDetailAllItemsResponse> => {
+}: GetPopUpDetailAllItemsRequest): ApiResponse<GetPopUpDetailAllItemsResponse> => {
   const response = await api.get(
     `/items/${popupId}?${lastItemId ? `lastItemId=${lastItemId}` : ''}&size=${SEARCH_SIZE}`,
   );

--- a/src/hooks/api/usePopUpAllItemsApi.ts
+++ b/src/hooks/api/usePopUpAllItemsApi.ts
@@ -1,0 +1,30 @@
+import { getPopUpAllItems } from '@/apis/home/HomeApi';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export const usePopUpAllItemsApi = () => {
+  const query = useInfiniteQuery({
+    queryFn: ({ pageParam }) =>
+      getPopUpAllItems({
+        lastPopupId: pageParam,
+      }),
+    queryKey: ['popups'],
+    getNextPageParam: response => {
+      const lastPage = response.data;
+
+      if (lastPage.isLast) {
+        return undefined;
+      }
+
+      const lastItem = lastPage.content[lastPage.content.length - 1];
+      return lastItem.popupId;
+    },
+    initialPageParam: undefined as number | undefined,
+  });
+
+  return {
+    allItems: query.data?.pages.flatMap(data => data.data.content),
+    isItemLoading: query.isLoading,
+    isItemError: query.isError,
+    allItemsQuery: query,
+  };
+};

--- a/src/hooks/api/usePopUpDetailApi.ts
+++ b/src/hooks/api/usePopUpDetailApi.ts
@@ -1,4 +1,4 @@
-import { getPopUDetailAllItems } from '@/apis/popUpDetail/PopUpDetailApi';
+import { getPopUpDetailAllItems } from '@/apis/popUpDetail/PopUpDetailApi';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getPopUpDetailInfo } from '@/apis/popUpDetail/PopUpDetailApi';
 import { GetPopUpDetailRequest } from '@/types/api/ApiRequestType';
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 export const usePopUpDetailAllItemsApi = ({ popupId }: { popupId: number }) => {
   const query = useInfiniteQuery({
     queryFn: ({ pageParam }) =>
-      getPopUDetailAllItems({
+      getPopUpDetailAllItems({
         popupId,
         lastItemId: pageParam,
       }),

--- a/src/mocks/HomeMocks.ts
+++ b/src/mocks/HomeMocks.ts
@@ -1,4 +1,4 @@
-import { GetHotPopUpItemsResponse, GetPopUpItemsResponse } from '@/types/api/ApiResponseType';
+import { GetHotPopUpItemsResponse } from '@/types/api/ApiResponseType';
 import { BannerItemType } from '@/types/HomeScreenType';
 
 const Images = {
@@ -60,73 +60,6 @@ export const hotItems: GetHotPopUpItemsResponse = [
     popupId: 4,
     popupName: '여자친구 Season of Memories 여자친구 Season of Memories',
     imageUrl: Images.popUp01,
-    popupOpenDate: '2025-05-01',
-    popupCloseDate: '2025-06-09',
-    address: '서울 영등포구 여의대로 108 더현대서울',
-  },
-];
-
-export const popUpItems: GetPopUpItemsResponse = [
-  {
-    popupId: 1,
-    popupName: '여자친구 Season of Memories 여자친구 Season of Memories',
-    imageUrl: Images.popUp01,
-    popupOpenDate: '2025-05-01',
-    popupCloseDate: '2025-06-09',
-    address: '서울 영등포구 여의대로 108 더현대서울',
-  },
-  {
-    popupId: 2,
-    popupName: '여자친구 Season of Memories 여자친구 Season of Memories',
-    imageUrl: Images.popUp02,
-    popupOpenDate: '2025-05-01',
-    popupCloseDate: '2025-06-09',
-    address: '서울 영등포구 여의대로 108 더현대서울',
-  },
-  {
-    popupId: 3,
-    popupName: '여자친구 Season of Memories 여자친구 Season of Memories',
-    imageUrl: Images.popUp03,
-    popupOpenDate: '2025-05-01',
-    popupCloseDate: '2025-06-09',
-    address: '서울 영등포구 여의대로 108 더현대서울',
-  },
-  {
-    popupId: 4,
-    popupName: '여자친구 Season of Memories 여자친구 Season of Memories',
-    imageUrl: Images.popUp01,
-    popupOpenDate: '2025-05-01',
-    popupCloseDate: '2025-06-09',
-    address: '서울 영등포구 여의대로 108 더현대서울',
-  },
-  {
-    popupId: 5,
-    popupName: '여자친구 Season of Memories 여자친구 Season of Memories',
-    imageUrl: Images.popUp02,
-    popupOpenDate: '2025-05-01',
-    popupCloseDate: '2025-06-09',
-    address: '서울 영등포구 여의대로 108 더현대서울',
-  },
-  {
-    popupId: 6,
-    popupName: '여자친구 Season of Memories 여자친구 Season of Memories',
-    imageUrl: Images.popUp03,
-    popupOpenDate: '2025-05-01',
-    popupCloseDate: '2025-06-09',
-    address: '서울 영등포구 여의대로 108 더현대서울',
-  },
-  {
-    popupId: 7,
-    popupName: '여자친구 Season of Memories 여자친구 Season of Memories',
-    imageUrl: Images.popUp01,
-    popupOpenDate: '2025-05-01',
-    popupCloseDate: '2025-06-09',
-    address: '서울 영등포구 여의대로 108 더현대서울',
-  },
-  {
-    popupId: 8,
-    popupName: '여자친구 Season of Memories 여자친구 Season of Memories',
-    imageUrl: Images.popUp02,
     popupOpenDate: '2025-05-01',
     popupCloseDate: '2025-06-09',
     address: '서울 영등포구 여의대로 108 더현대서울',

--- a/src/store/usePopUpStore.ts
+++ b/src/store/usePopUpStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 type StoreType = {
   selectedPopUpId: number;
+  setSelectedPopUpId: (popUpId: number) => void;
 };
 
 export const usePopUpStore = create<StoreType>()(set => ({

--- a/src/types/HomeScreenType.ts
+++ b/src/types/HomeScreenType.ts
@@ -7,7 +7,7 @@ export type BannerItemType = {
 export type PopUpItem = {
   popupId: number;
   popupName: string;
-  imageUrl: number; // 추후 string으로 변경
+  imageUrl: string;
   popupOpenDate: string;
   popupCloseDate: string;
   address: string;

--- a/src/types/api/ApiRequestType.ts
+++ b/src/types/api/ApiRequestType.ts
@@ -31,11 +31,15 @@ export type GetSurveyQuestionsRequest = {
   popupId: number;
 };
 
-export type GetPopUDetailAllItemsRequest = {
+export type GetPopUpDetailAllItemsRequest = {
   popupId: number;
   lastItemId: number | undefined;
 };
 
 export type GetPopUpDetailRequest = {
   popupId: number;
+};
+
+export type GetPopUpAllItemsRequest = {
+  lastPopupId: number | undefined;
 };

--- a/src/types/api/ApiResponseType.ts
+++ b/src/types/api/ApiResponseType.ts
@@ -90,7 +90,10 @@ export type GetPopUpMarkerItemsResponse = popUpMarkerItem[];
 
 export type GetHotPopUpItemsResponse = HotPopUpItem[];
 
-export type GetPopUpItemsResponse = PopUpItem[];
+export type GetPopUpAllItemsResponse = {
+  content: PopUpItem[];
+  isLast: boolean;
+};
 
 export type GetReservationDetailResponse = {
   popupName: string;


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-253]

---

## 📌 작업 내용 및 특이사항

- 전체 팝업 목록 조회 API 구현하였습니다.
- react-query에서 제공해주는 getNextPageParam으로 popupId로 인식해서 queryFn에 pageParam에 자동으로 넣어 무한스크롤을 제공합니다.
- ScrollView 와 FlatList를 함께 썼을 때 오류가 나서 FlatList로 크게 감싸는 형태로 Home 페이지 코드를 변경하였습니다.
- usePopUpStore를 사용해 한 개의 팝업을 클릭 시 setSelectedPopUpId 로 전역 상태 변수가 변경되도록 하였습니다.
- popUDetail -> popUpDetail 로 오타 수정하였습니다. @sung-yeop 
---

## 📚 참고사항
<img width="395" alt="image" src="https://github.com/user-attachments/assets/09985ce7-8b95-41db-bc55-332d3d36ed50" />



[LCR-253]: https://lgcns-retail.atlassian.net/browse/LCR-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ