### PR TITLE
fix: 장바구니 상품 재고 수량 제한 로직 추가

### DIFF
--- a/app/(common)/search/index.tsx
+++ b/app/(common)/search/index.tsx
@@ -11,10 +11,7 @@ export default function SearchScreen() {
   const { keyword } = useSearchStore();
   const searchMode = keyword.trim().length > 0 && true;
 
-  const renderItem = useCallback(
-    ({ item }: { item: PostPopUpSearch }) => <SearchResultPopUpItem {...item} />,
-    [],
-  );
+  const renderItem = ({ item }: { item: PostPopUpSearch }) => <SearchResultPopUpItem {...item} />;
 
   const renderHeader = useCallback(() => {
     if (searchResult.length > 0 && !isLoading) {

--- a/app/(tabs)/cart/index.tsx
+++ b/app/(tabs)/cart/index.tsx
@@ -43,6 +43,14 @@ export default function CartScreen() {
   const getTotalPrice = () =>
     cartItems.reduce((sum, item) => (item.selected ? sum + item.price * item.quantity : sum), 0);
 
+  const canPlusItem = (item: CartItem) => {
+    return item.quantity < 3;
+  };
+
+  const canMinusItem = (item: CartItem) => {
+    return item.quantity > 1;
+  };
+
   const handlePaymentResponse = (response: any) => {
     if (response.success) {
       router.push({
@@ -54,8 +62,8 @@ export default function CartScreen() {
     } else {
       const errorData = response.data as PostPaymentReadyErrorResponse;
       setErrorMsg(errorData.message);
-      // 에러 API 명세에 따라 수정 필요
-      setErrorItemId(1);
+      // TODO : 에러 API 명세 수정시 변경 필요
+      setErrorItemId(errorData.itemId);
     }
   };
 
@@ -102,11 +110,25 @@ export default function CartScreen() {
       <S.ItemBottomRow>
         <S.QuantityWrapper>
           <S.QuantityButton onPress={() => changeQuantity(item.itemId, -1)}>
-            <Image source={Images.minusIcon} style={{ width: 14, height: 14 }} />
+            <Image
+              source={Images.minusIcon}
+              style={{
+                width: 14,
+                height: 14,
+                tintColor: canMinusItem(item) ? '' : 'gray',
+              }}
+            />
           </S.QuantityButton>
           <S.QuantityText>{item.quantity}</S.QuantityText>
           <S.QuantityButton onPress={() => changeQuantity(item.itemId, 1)}>
-            <Image source={Images.plusIcon} style={{ width: 14, height: 14 }} />
+            <Image
+              source={Images.plusIcon}
+              style={{
+                width: 14,
+                height: 14,
+                tintColor: canPlusItem(item) ? '' : 'gray',
+              }}
+            />
           </S.QuantityButton>
         </S.QuantityWrapper>
         <View style={{ flex: 1 }} />

--- a/src/components/searchScreen/searchResultPopUp/SearchResultPopUpItem.tsx
+++ b/src/components/searchScreen/searchResultPopUp/SearchResultPopUpItem.tsx
@@ -3,6 +3,7 @@ import { PostPopUpSearch } from '@/types/SearchScreenType';
 import { useRouter } from 'expo-router';
 import { Dimensions } from 'react-native';
 import { S } from './SearchResultPopUpItem.style';
+import { usePopUpStore } from '@/store/usePopUpStore';
 
 const { width } = Dimensions.get('window');
 
@@ -23,10 +24,12 @@ export default function SearchResultPopUpItem({
   const GAP = 12;
   const realWidth = (width - 2 * PADDING - GAP) / 2;
 
+  usePopUpStore.getState().setSelectedPopUpId(popupId);
+
   return (
     <S.PopUpContainer
       style={{ width: realWidth }}
-      onPress={() => router.replace({ pathname: '/(common)/popUpDetail', params: { popupId } })}
+      onPress={() => router.replace({ pathname: '/(common)/popUpDetail' })}
     >
       <S.PopUpImage
         source={{ uri: imageUrl }}

--- a/src/hooks/api/usePopUpDetailApi.ts
+++ b/src/hooks/api/usePopUpDetailApi.ts
@@ -44,7 +44,7 @@ export const usePopUpDetailAllItemsApi = ({ popupId }: { popupId: number }) => {
 export const usePopUpDetailApi = ({ popupId }: GetPopUpDetailRequest) => {
   const query = useQuery({
     queryFn: () => getPopUpDetailInfo({ popupId }),
-    queryKey: ['popup', popupId],
+    queryKey: ['popupDetail', popupId],
   });
 
   return {

--- a/src/store/useCartStore.ts
+++ b/src/store/useCartStore.ts
@@ -25,7 +25,9 @@ export const useCartStore = create<CartState & CartActions>(set => ({
   changeQuantity: (itemId, delta) =>
     set(state => ({
       cartItems: state.cartItems.map(item =>
-        item.itemId === itemId ? { ...item, quantity: Math.max(1, item.quantity + delta) } : item,
+        item.itemId === itemId
+          ? { ...item, quantity: Math.max(1, Math.min(3, item.quantity + delta)) }
+          : item,
       ),
     })),
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-296]

---

## 📌 작업 내용 및 특이사항

- 장바구니에 상품을 최대 3개까지만 추가할 수 있도록 재고 수량 추가 로직 수정했습니다


[LCR-296]: https://lgcns-retail.atlassian.net/browse/LCR-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ